### PR TITLE
Merge multidb secondary DB features to master

### DIFF
--- a/c_src/erocksdb.cc
+++ b/c_src/erocksdb.cc
@@ -52,6 +52,7 @@ static ErlNifFunc nif_funcs[] =
         {"flush", 3, erocksdb::Flush, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"sync_wal", 1, erocksdb::SyncWal, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"set_db_background_threads", 2, erocksdb::SetDBBackgroundThreads, ERL_NIF_REGULAR_BOUND},
+        {"try_catch_up_with_primary", 1, erocksdb::TryCatchUpWithPrimary, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
         {"get_approximate_sizes", 3, erocksdb::GetApproximateSizes, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"get_approximate_sizes", 4, erocksdb::GetApproximateSizes, ERL_NIF_DIRTY_JOB_IO_BOUND},

--- a/c_src/erocksdb.cc
+++ b/c_src/erocksdb.cc
@@ -33,8 +33,10 @@ static ErlNifFunc nif_funcs[] =
 
         {"open", 2, erocksdb::Open, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"open_readonly", 2, erocksdb::OpenReadOnly, ERL_NIF_DIRTY_JOB_IO_BOUND},
+        {"open_secondary", 3, erocksdb::OpenSecondary, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"open", 3, erocksdb::OpenWithCf, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"open_readonly", 3, erocksdb::OpenWithCfReadOnly, ERL_NIF_DIRTY_JOB_IO_BOUND},
+        {"open_secondary", 4, erocksdb::OpenWithCfSecondary, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"open_with_ttl", 4, erocksdb::OpenWithTTL, ERL_NIF_DIRTY_JOB_IO_BOUND},
         {"open_optimistic_transaction_db", 3,
          erocksdb::OpenOptimisticTransactionDB, ERL_NIF_DIRTY_JOB_IO_BOUND},

--- a/c_src/erocksdb.h
+++ b/c_src/erocksdb.h
@@ -39,6 +39,7 @@ ERL_NIF_TERM CompactRange(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM SetDBBackgroundThreads(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM GetApproximateSizes(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM GetApproximateMemTableStats(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM TryCatchUpWithPrimary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM ListColumnFamilies(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM CreateColumnFamily(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/c_src/erocksdb.h
+++ b/c_src/erocksdb.h
@@ -26,8 +26,10 @@ namespace erocksdb {
 
 ERL_NIF_TERM Open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM OpenReadOnly(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM OpenSecondary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM OpenWithCf(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM OpenWithCfReadOnly(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM OpenWithCfSecondary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM OpenWithTTL(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM OpenOptimisticTransactionDB(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM Close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -1005,6 +1005,10 @@ parse_cf_descriptor(ErlNifEnv* env, ERL_NIF_TERM item,
 
 namespace erocksdb {
 
+
+    enum class open_mode { primary, secondary, read_only };
+
+
 // Base Open function.
 //
 // This `Open` function is not called by directly the VM due to the
@@ -1015,38 +1019,54 @@ Open(
     ErlNifEnv* env,
     int /*argc*/,
     const ERL_NIF_TERM argv[],
-    bool read_only)
+    open_mode const mode)
 {
-    char db_name[4096];
+    char db_name[4096], secondary[4096];
     DbObject * db_ptr;
-    rocksdb::DB *db(0);
+    rocksdb::DB *db = nullptr;
 
 
-    if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
-       !enif_is_list(env, argv[1]))
-    {
-        return enif_make_badarg(env);
+    auto db_opts = std::make_unique<rocksdb::DBOptions>();
+    auto cf_opts = std::make_unique<rocksdb::ColumnFamilyOptions>();
+
+    switch (mode) {
+    case open_mode::primary: [[fallthrough]];
+    case open_mode::read_only:
+        if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
+        !enif_is_list(env, argv[1]))
+        {
+            return enif_make_badarg(env);
+        }
+        fold(env, argv[1], parse_db_option, *db_opts);
+        fold(env, argv[1], parse_cf_option, *cf_opts);
+        break;
+    case open_mode::secondary:
+        if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
+            !enif_get_string(env, argv[1], secondary, sizeof(secondary), ERL_NIF_LATIN1) ||
+            !enif_is_list(env, argv[2]))
+        {
+            return enif_make_badarg(env);
+        }
+        fold(env, argv[2], parse_db_option, *db_opts);
+        fold(env, argv[2], parse_cf_option, *cf_opts);
+        break;
     }
-
-    // parse db options
-    rocksdb::DBOptions *db_opts = new rocksdb::DBOptions;
-    fold(env, argv[1], parse_db_option, *db_opts);
-
-    // parse column family options
-    rocksdb::ColumnFamilyOptions *cf_opts = new rocksdb::ColumnFamilyOptions;
-    fold(env, argv[1], parse_cf_option, *cf_opts);
 
     // final options
-    rocksdb::Options *opts = new rocksdb::Options(*db_opts, *cf_opts);
+    auto opts = std::make_unique<rocksdb::Options>(*db_opts, *cf_opts);
     rocksdb::Status status;
-    if (read_only) {
-        status = rocksdb::DB::OpenForReadOnly(*opts, db_name, &db);
-    } else {
+    switch (mode) {
+    case open_mode::primary:
         status = rocksdb::DB::Open(*opts, db_name, &db);
+        break;
+    case open_mode::secondary:
+        opts->max_open_files = -1;
+        status = rocksdb::DB::OpenAsSecondary(*opts, db_name, secondary, &db);
+        break;
+    case open_mode::read_only:
+        status = rocksdb::DB::OpenForReadOnly(*opts, db_name, &db);
+        break;
     }
-    delete opts;
-    delete db_opts;
-    delete cf_opts;
 
     if(!status.ok())
         return error_tuple(env, ATOM_ERROR_DB_OPEN, status);
@@ -1063,13 +1083,18 @@ Open(
     int argc,
     const ERL_NIF_TERM argv[])
 {
-    return Open(env, argc, argv, false);
+    return Open(env, argc, argv, open_mode::primary);
 } // Open
 
 ERL_NIF_TERM
 OpenReadOnly(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
-    return Open(env, argc, argv, true);
+    return Open(env, argc, argv, open_mode::read_only);
 } // OpenReadOnly
+
+ERL_NIF_TERM
+OpenSecondary(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[]) {
+    return Open(env, argc, argv, open_mode::secondary);
+} // OpenSecondary
 
 // Base OpenWithCf function.
 //
@@ -1081,25 +1106,42 @@ OpenWithCf(
     ErlNifEnv* env,
     int /*argc*/,
     const ERL_NIF_TERM argv[],
-    bool read_only)
+    open_mode const mode)
 {
-    char db_name[4096];
+    char db_name[4096], secondary[4096];
     DbObject * db_ptr;
-    rocksdb::DB *db(0);
+    rocksdb::DB *db = nullptr;
 
-
-    if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
-       !enif_is_list(env, argv[1]) || !enif_is_list(env, argv[2]))
-    {
-        return enif_make_badarg(env);
-    }   // if
-
-    // read db options
     rocksdb::DBOptions db_opts;
-    fold(env, argv[1], parse_db_option, db_opts);
-
     std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
-    ERL_NIF_TERM head, tail = argv[2];
+    ERL_NIF_TERM head, tail;
+    unsigned int num_cols;
+
+    switch (mode) {
+    case open_mode::primary: [[fallthrough]];
+    case open_mode::read_only:
+        if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
+        !enif_is_list(env, argv[1]) || !enif_is_list(env, argv[2]))
+        {
+            return enif_make_badarg(env);
+        }   // if
+        fold(env, argv[1], parse_db_option, db_opts);
+        tail = argv[2];
+        enif_get_list_length(env, argv[2], &num_cols);
+        break;
+    case open_mode::secondary:
+        if(!enif_get_string(env, argv[0], db_name, sizeof(db_name), ERL_NIF_LATIN1) ||
+            !enif_get_string(env, argv[1], secondary, sizeof(secondary), ERL_NIF_LATIN1) ||
+        !enif_is_list(env, argv[2]) || !enif_is_list(env, argv[3]))
+        {
+            return enif_make_badarg(env);
+        }   // if
+        fold(env, argv[2], parse_db_option, db_opts);
+        tail = argv[3];
+        enif_get_list_length(env, argv[3], &num_cols);
+        break;
+    }
+
     while(enif_get_list_cell(env, tail, &head, &tail))
     {
         ERL_NIF_TERM result = parse_cf_descriptor(env, head, column_families);
@@ -1111,10 +1153,16 @@ OpenWithCf(
 
     std::vector<rocksdb::ColumnFamilyHandle*> handles;
     rocksdb::Status status;
-    if (read_only) {
-        status = rocksdb::DB::OpenForReadOnly(db_opts, db_name, column_families, &handles, &db);
-    } else {
+    switch (mode) {
+    case open_mode::primary:
         status = rocksdb::DB::Open(db_opts, db_name, column_families, &handles, &db);
+        break;
+    case open_mode::secondary:
+        status = rocksdb::DB::OpenAsSecondary(db_opts, db_name, secondary, column_families, &handles, &db);
+        break;
+    case open_mode::read_only:
+        status = rocksdb::DB::OpenForReadOnly(db_opts, db_name, column_families, &handles, &db);
+        break;
     }
 
     if(!status.ok())
@@ -1123,9 +1171,6 @@ OpenWithCf(
     db_ptr = DbObject::CreateDbObject(std::move(db));
 
     ERL_NIF_TERM result = enif_make_resource(env, db_ptr);
-
-    unsigned int num_cols;
-    enif_get_list_length(env, argv[2], &num_cols);
 
     ERL_NIF_TERM cf_list = enif_make_list(env, 0);
     try {
@@ -1156,7 +1201,7 @@ OpenWithCf(
     int argc,
     const ERL_NIF_TERM argv[])
 {
-    return OpenWithCf(env, argc, argv, false);
+    return OpenWithCf(env, argc, argv, open_mode::primary);
 } // OpenWithCf
 
 ERL_NIF_TERM
@@ -1165,7 +1210,16 @@ OpenWithCfReadOnly(
     int argc,
     const ERL_NIF_TERM argv[])
 {
-    return OpenWithCf(env, argc, argv, true);
+    return OpenWithCf(env, argc, argv, open_mode::read_only);
+}
+
+ERL_NIF_TERM
+OpenWithCfSecondary(
+    ErlNifEnv* env,
+    int argc,
+    const ERL_NIF_TERM argv[])
+{
+    return OpenWithCf(env, argc, argv, open_mode::secondary);
 }
 
 ERL_NIF_TERM

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -1158,6 +1158,7 @@ OpenWithCf(
         status = rocksdb::DB::Open(db_opts, db_name, column_families, &handles, &db);
         break;
     case open_mode::secondary:
+        db_opts.max_open_files = -1;
         status = rocksdb::DB::OpenAsSecondary(db_opts, db_name, secondary, column_families, &handles, &db);
         break;
     case open_mode::read_only:

--- a/c_src/erocksdb_db.cc
+++ b/c_src/erocksdb_db.cc
@@ -1935,6 +1935,21 @@ GetApproximateMemTableStats(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 }
 
 ERL_NIF_TERM
+TryCatchUpWithPrimary(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    ReferencePtr<DbObject> db_ptr;
+
+    if (!enif_get_db(env, argv[0], &db_ptr))
+        return enif_make_badarg(env);
+
+    if (auto status = db_ptr->m_Db->TryCatchUpWithPrimary(); status.ok()) {
+        return erocksdb::ATOM_OK;
+    } else {
+        return error_tuple(env, ATOM_ERROR, status);
+    }
+}
+
+ERL_NIF_TERM
 CompactRange(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     ReferencePtr<DbObject> db_ptr;

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -40,7 +40,8 @@
   stats/1, stats/2,
   get_property/2, get_property/3,
   get_approximate_sizes/3, get_approximate_sizes/4,
-  get_approximate_memtable_stats/3, get_approximate_memtable_stats/4
+  get_approximate_memtable_stats/3, get_approximate_memtable_stats/4,
+  try_catch_up_with_primary/1
 ]).
 
 -export([open_with_cf/3, open_with_cf_readonly/3]).
@@ -866,6 +867,14 @@ get_approximate_memtable_stats(_DBHandle, _StartKey, _LimitKey) ->
   LimitKey :: binary(),
   Res :: {ok, {Count::non_neg_integer(), Size::non_neg_integer()}}.
 get_approximate_memtable_stats(_DBHandle, _CFHandle, _StartKey, _LimitKey) ->
+  ?nif_stub.
+
+%% @doc Attempts to catch a secondary connection up to the current
+%% position of the primary connection.
+-spec try_catch_up_with_primary(DBHandle) -> Res when
+  DBHandle :: db_handle(),
+  Res :: ok | {error, any()}.
+try_catch_up_with_primary(_DBHandle) ->
   ?nif_stub.
 
 %% @doc Removes the database entries in the range ["BeginKey", "EndKey"), i.e.,

--- a/src/rocksdb.erl
+++ b/src/rocksdb.erl
@@ -22,6 +22,7 @@
 -export([
   open/2, open/3,
   open_readonly/2, open_readonly/3,
+  open_secondary/3, open_secondary/4,
   open_optimistic_transaction_db/2, open_optimistic_transaction_db/3,
   open_with_ttl/4,
   close/1,
@@ -522,6 +523,13 @@ open(_Name, _DBOpts) ->
 open_readonly(_Name, _DBOpts) ->
   ?nif_stub.
 
+-spec open_secondary(Name, Name, DBOpts) -> Result when
+  Name :: file:filename_all(),
+  DBOpts :: options(),
+  Result :: {ok, db_handle()} | {error, any()}.
+open_secondary(_Primary, _Name, _DBOpts) ->
+  ?nif_stub.
+
 %% @doc Open RocksDB with the specified column families
 -spec(open(Name, DBOpts, CFDescriptors) ->
        {ok, db_handle(), list(cf_handle())} | {error, any()}
@@ -538,6 +546,15 @@ open(_Name, _DBOpts, _CFDescriptors) ->
           DBOpts :: db_options(),
           CFDescriptors :: list(cf_descriptor())).
 open_readonly(_Name, _DBOpts, _CFDescriptors) ->
+  ?nif_stub.
+
+-spec open_secondary(Name, Name, DBOpts, CFDescriptors) ->
+      {ok, db_handle(), list(cf_handle())} | {error, any()}
+        when
+          Name :: file:filename_all(),
+          DBOpts :: options(),
+          CFDescriptors :: list(cf_descriptor()).
+open_secondary(_Primary, _Name, _DBOpts, _CFDescriptors) ->
   ?nif_stub.
 
 open_with_cf(Name, DbOpts, CFDescriptors) ->

--- a/test/secondary.erl
+++ b/test/secondary.erl
@@ -1,0 +1,37 @@
+-module(secondary).
+
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+secondary_connection_test() ->
+    Dir1 = "erocksdb.secondary1.test",
+    rocksdb_test_util:rm_rf(Dir1),
+    Dir2 = "erocksdb.secondary2.test",
+    rocksdb_test_util:rm_rf(Dir2),
+    {ok, Ref1} = rocksdb:open(Dir1, [{create_if_missing, true}]),
+    ok = rocksdb:put(Ref1, <<"abc">>, <<"123">>, []),
+    {ok, Ref2} = rocksdb:open_secondary(Dir1, Dir2, []),
+    {ok, <<"123">>} = rocksdb:get(Ref2, <<"abc">>, []),
+    ok = rocksdb:close(Ref2),
+    ok = rocksdb:close(Ref1),
+    rocksdb_test_util:rm_rf(Dir2),
+    rocksdb_test_util:rm_rf(Dir1).
+
+
+secondary_connection_with_cf_test() ->
+    Dir1 = "erocksdb.secondary1.test",
+    rocksdb_test_util:rm_rf(Dir1),
+    Dir2 = "erocksdb.secondary2.test",
+    rocksdb_test_util:rm_rf(Dir2),
+    {ok, Ref1, [DefaultCF1, AnotherCF1]} = rocksdb:open(Dir1,
+        [{create_if_missing, true}, {create_missing_column_families, true}],
+        [{"default", []}, {"another", []}]),
+    ok = rocksdb:put(Ref1, <<"abc">>, <<"123">>, []),
+    {ok, Ref2, [DefaultCF2, AnotherCF2]} = rocksdb:open_secondary(Dir1, Dir2, [],
+        [{"default", []}, {"another", []}]),
+    {ok, <<"123">>} = rocksdb:get(Ref2, <<"abc">>, []),
+    ok = rocksdb:close(Ref2),
+    ok = rocksdb:close(Ref1),
+    rocksdb_test_util:rm_rf(Dir2),
+    rocksdb_test_util:rm_rf(Dir1).

--- a/test/secondary.erl
+++ b/test/secondary.erl
@@ -5,14 +5,18 @@
 
 
 secondary_connection_test() ->
-    Dir1 = "erocksdb.secondary1.test",
+    Dir1 = "erocksdb.secondary1.test1",
     rocksdb_test_util:rm_rf(Dir1),
-    Dir2 = "erocksdb.secondary2.test",
+    Dir2 = "erocksdb.secondary2.test1",
     rocksdb_test_util:rm_rf(Dir2),
     {ok, Ref1} = rocksdb:open(Dir1, [{create_if_missing, true}]),
     ok = rocksdb:put(Ref1, <<"abc">>, <<"123">>, []),
     {ok, Ref2} = rocksdb:open_secondary(Dir1, Dir2, []),
     {ok, <<"123">>} = rocksdb:get(Ref2, <<"abc">>, []),
+    ok = rocksdb:put(Ref1, <<"def">>, <<"456">>, []),
+    not_found = rocksdb:get(Ref2, <<"def">>, []),
+    ok = rocksdb:try_catch_up_with_primary(Ref2),
+    {ok, <<"456">>} = rocksdb:get(Ref2, <<"def">>, []),
     ok = rocksdb:close(Ref2),
     ok = rocksdb:close(Ref1),
     rocksdb_test_util:rm_rf(Dir2),
@@ -20,9 +24,9 @@ secondary_connection_test() ->
 
 
 secondary_connection_with_cf_test() ->
-    Dir1 = "erocksdb.secondary1.test",
+    Dir1 = "erocksdb.secondary1.test2",
     rocksdb_test_util:rm_rf(Dir1),
-    Dir2 = "erocksdb.secondary2.test",
+    Dir2 = "erocksdb.secondary2.test2",
     rocksdb_test_util:rm_rf(Dir2),
     {ok, Ref1, [DefaultCF1, AnotherCF1]} = rocksdb:open(Dir1,
         [{create_if_missing, true}, {create_missing_column_families, true}],
@@ -31,6 +35,10 @@ secondary_connection_with_cf_test() ->
     {ok, Ref2, [DefaultCF2, AnotherCF2]} = rocksdb:open_secondary(Dir1, Dir2, [],
         [{"default", []}, {"another", []}]),
     {ok, <<"123">>} = rocksdb:get(Ref2, <<"abc">>, []),
+    ok = rocksdb:put(Ref1, <<"def">>, <<"456">>, []),
+    not_found = rocksdb:get(Ref2, <<"def">>, []),
+    ok = rocksdb:try_catch_up_with_primary(Ref2),
+    {ok, <<"456">>} = rocksdb:get(Ref2, <<"def">>, []),
     ok = rocksdb:close(Ref2),
     ok = rocksdb:close(Ref1),
     rocksdb_test_util:rm_rf(Dir2),


### PR DESCRIPTION
## Summary

Cherry-picks the 3 commits from the `multidb` branch onto current `master`:

1. Add the ability to open a secondary database connection, with and without column families
2. Add an API for catching the secondary up to the primary (`try_catch_up_with_primary`)
3. Bug fix for secondary DB options

These features are required by PersistenceStore for its primary/secondary read pattern. The `multidb` branch was 2 years behind master (Nov 2023) and missing OTP 27 build fixes.

## Test plan

- [x] Clean cherry-pick, no conflicts
- [x] Compiles on OTP 27 / Debian 12
- [ ] Run EventStore + PersistenceStore test suites against this branch